### PR TITLE
Huge refactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@
 
 > The _"Java Version Manager"_
 
-Automatically change `JAVA_HOME` based on current directory `pom.xml`
-or `.java-version` files.
+Automatically change `JAVA_HOME` based on current directory `.java-version`
+file.
 
-The philosophy behind this project is to simplify and automatize the `JAVA_HOME`
+The philosophy behind this project is to simplify and automate the `JAVA_HOME`
 changing, much like `rbenv` and `rvm` do for Ruby.
 
 It's pretty common to have to work in Java 6, 7 and 8 projects, and changing
-`PATH`s and `JAVA_HOME`s by hand is annoying.
+`PATH`s and `JAVA_HOME`s by hand is a very repetitive task.
 
 ### Usage
 
-```sh
+```console
 $ git clone https://github.com/caarlos0/jvm.git ~/.jvm
+$ echo ".java-version" >> ~/.gitignore
 
 # for bash
 $ echo "source ~/.jvm/jvm.sh" >> ~/.bashrc
@@ -23,14 +24,13 @@ $ echo "source ~/.jvm/jvm.sh" >> ~/.bashrc
 $ echo "source ~/.jvm/jvm.sh" >> ~/.zshrc
 ```
 
-Then, just `cd` to a java project folder. If the `pom.xml`  has a
-`<java.version>1.7</java.version>`, for example, `jvm` will try to
-set JDK7 to your PATH.
+Then, just `cd` to a java project folder. `jvm` will call `mvn help:evaluate`
+asking for the source compiler version, and then, set it to `.java-version`.
+If the `.java-version` file already exists, it will just use what's in there.
 
-If you don't have and don't want to have this in your project's pom,
-you can also do this:
+You can always change the current folder java version by doing:
 
-```sh
+```console
 $ jvm local 7
 ```
 
@@ -39,34 +39,22 @@ Ubuntu, right now `jvm` has `/usr/lib/jvm/java-${version}-oracle/` hard coded.
 This might change soon. If you need custom versions, like `6-openjdk`, for
 example, you can run `jvm config` and add a line like this:
 
-```
+```properties
 6-openjdk=/path/to/openjdk/6
 ```
 
 And `jvm` will automagically works.
 
-### `jvm` commands
-
-Right now, `jvm` has the following commands:
-
-- `local VERSION`: creates a `.java-version` in the current dir with the given
-version;
-- `global VERSION`: creates a `.java-version` in your `$HOME` dir with the given
-version;
-- `jvm config`: opens the `~/.jvmconfig` file in your default `$EDITOR`. Useful
-for defining custom versions and/or paths;
-- `version`: shows current version;
-- `help`: shows the help.
+And, yes, this strategy (based on `jvm config`) can make `jvm` work on Windows
+with any `bash` terminal too. Or any other operating system with a POSIX shell
+really.
 
 ### Antigen/Antibody
 
-For those using Antigen/Antibody, just hit
+For those using Antigen, Antibody or whatever, just bundle `caarlos0/jvm`, as
+in:
 
-```sh
-# for antigen
-$ antigen  bundle caarlos0/jvm
-
-# for antibody
+```console
 $ antibody bundle caarlos0/jvm
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ $ echo "source ~/.jvm/jvm.sh" >> ~/.bashrc
 $ echo "source ~/.jvm/jvm.sh" >> ~/.zshrc
 ```
 
-Then, just `cd` to a java project folder. `jvm` will call `mvn help:evaluate`
-asking for the source compiler version, and then, set it to `.java-version`.
-If the `.java-version` file already exists, it will just use what's in there.
+Then, just `cd` to a java project folder. `jvm` will try to extract the version
+using a regular expression. If that fails, `jvm` will then call
+`mvn help:evaluate` asking for the source compiler version, and then, set it to
+`.java-version`. If the `.java-version` file already exists, it will just use
+what's in there.
 
 You can always change the current folder java version by doing:
 

--- a/jvm.sh
+++ b/jvm.sh
@@ -7,7 +7,7 @@ __jvm_set() {
 
   # custom jdk strategy
   test -f ~/.jvmconfig && \
-    new="$(grep "$version"= ~/.jvmconfig | cut -f2 -d'=')"
+    new="$(grep "$version"= ~/.jvmconfig || true | cut -f2 -d'=')"
 
   # ubuntu/debian jdk strategy
   test -z "$new" -a -d "/usr/lib/jvm/java-${version}-oracle/" && \

--- a/jvm.sh
+++ b/jvm.sh
@@ -1,66 +1,88 @@
 #!/bin/sh
-# shellcheck disable=SC2039
-_jvm_set-java-path() {
+# find the appropriate JAVA_HOME for the given java version and fix PATH.
+__jvm_set() {
   version="$1"
-  previous_java_home="$JAVA_HOME"
-  new_java_home=""
-  if [ -f ~/.jvmconfig ]; then
-    new_java_home="$(grep "${version}"= ~/.jvmconfig | cut -f2 -d'=')"
-  elif [ -d "/usr/lib/jvm/java-${version}-oracle/" ]; then
-    new_java_home="/usr/lib/jvm/java-${version}-oracle/"
-  elif [ -e /usr/libexec/java_home ]; then
-    new_java_home="$(/usr/libexec/java_home -v 1."$version" || true)"
-  fi
-  if [ "$new_java_home" != "" ] && [ -d "$new_java_home" ]; then
-    if [ "$previous_java_home" != "" ] && [ "$previous_java_home" != "$new_java_home" ]; then
-      # shellcheck disable=SC2155
-      export PATH="$(echo "$PATH" | sed -e 's|'"$previous_java_home"'/bin:||g')"
-    fi
-    export JAVA_HOME="$new_java_home"
-    export PATH="${JAVA_HOME}/bin:$PATH"
-  fi
+  new=""
+  previous="$JAVA_HOME"
+
+  # custom jdk strategy
+  test -f ~/.jvmconfig && \
+    new="$(grep "$version"= ~/.jvmconfig | cut -f2 -d'=')"
+
+  # ubuntu/debian jdk strategy
+  test -z "$new" -a -d "/usr/lib/jvm/java-${version}-oracle/" && \
+    new="/usr/lib/jvm/java-${version}-oracle/"
+
+  # osx jdk strategy
+  test -z "$new" -a -e /usr/libexec/java_home && \
+    new="$(/usr/libexec/java_home -v 1."$version" || true)"
+
+  # sanity check: new must be a folder.
+  test ! -z "$new" -a -d "$new" || return 1
+
+  # PATH cleanup
+  # shellcheck disable=SC2155
+  test ! -z "$previous" -a "$previous" != "$new" && \
+    export PATH="$(echo "$PATH" | sed -e 's|'"$previous"'/bin:||g')"
+
+  # finally export new home and path
+  export JAVA_HOME="$new"
+  export PATH="${JAVA_HOME}/bin:$PATH"
 }
 
-# shellcheck disable=SC2039
-_jvm-discover-version() {
+# evaluates the 'maven.compiler.source' expression, saving its results to
+# .java-version (for further faster loading).
+__jvm_set_pom_version() {
+  MAVEN_OPTS="" mvn help:evaluate \
+    -Dexpression='maven.compiler.source' |
+    grep -v INFO | grep -v WARN | cut -f2 -d'.' > .java-version
+}
+
+# finds out which java version should be used.
+__jvm_version() {
   version=""
-  if [ -f pom.xml ]; then
-    version="$(\
-      grep '<java.version>' pom.xml | \
-      sed 's/.*<java.version>1.\(.*\)<\/java.version>.*/\1/' \
-    )"
-  fi
-  if [ -z "$version" ] && [ -f .java-version ]; then
-    version="$(cat .java-version)"
-  fi
-  if [ -z "$version" ] && [ -f ~/.java-version ]; then
-    version="$(cat ~/.java-version)"
-  fi
+  test ! -f .java-version -a -f pom.xml && __jvm_set_pom_version
+  test -f .java-version && version="$(cat .java-version)"
+  test -z "$version" -a -f ~/.java-version && version="$(cat ~/.java-version)"
   echo "$version"
 }
 
-# shellcheck disable=SC2039
-_jvm-discover-and-set-version() {
-  version="$(_jvm-discover-version)"
-  [ ! -z "$version" ] && _jvm_set-java-path "$version"
+# called when a dir changes. Find which java version to use and sets it to PATH.
+__jvm_main() {
+  version="$(__jvm_version)"
+  test ! -z "$version" && __jvm_set "$version"
 }
 
-# shellcheck disable=SC2039
-_jvm-edit-config() {
-  if [ ! -f ~/.jvmconfig ]; then
-    cat > ~/.jvmconfig <<EOF
-custom-jdk-7=Path to custom jdk 7
-custom-jdk-8=Path to custom jdk 8
-EOF
-  fi
+# edit custom java version configurations
+__jvm_config() {
+  test ! -f ~/.jvmconfig && echo "custom-jdk=/path/to/custom/jdk" > ~/.jvmconfig
   $EDITOR ~/.jvmconfig
 }
 
-# shellcheck disable=SC2039
-_jvm-command-list() {
-  echo "local global version reload config"
+# shows usage instructions
+__jvm_usage() {
+  cat <<EOF
+NAME:
+  jvm - The Java Version Manager
+
+USAGE:
+  jvm command [command options]
+
+AUTHOR(S):
+  Carlos Alexandro Becker (caarlos0@gmail.com)
+
+COMMANDS:
+  local   <version> sets the given version to current folder
+  global  <version> sets the given version globally
+  version           shows the version being used
+  reload            reloads jvm and re-sets the PATH and JAVA_HOME
+  config            opens jvm config file in your default editor
+  help              displays this help
+EOF
 }
 
+# utilitary function to user interaction with the jvm configs
+# (and further scripting).
 jvm() {
   command=""
   if [ "$#" != 0 ]; then
@@ -68,45 +90,46 @@ jvm() {
   fi
   case "$command" in
     local)
+      test -z "$@" && jvm help
       echo "$@" > .java-version
-      _jvm-discover-and-set-version
+      __jvm_main
       ;;
     global)
+      test -z "$@" && jvm help
       echo "$@" > ~/.java-version
-      _jvm-discover-and-set-version
+      __jvm_main
       ;;
     version)
-      _jvm-discover-version
+      __jvm_version
       ;;
     reload)
-      _jvm-discover-and-set-version
+      __jvm_main
       ;;
     config)
-      _jvm-edit-config
+      __jvm_config
       ;;
     *)
-      echo "Usage: jvm (${$(_jvm-command-list)// /|}) <args>"
+      __jvm_usage
       return 0
       ;;
   esac
 }
 
+# main function called when sourced.
 main() {
-  _jvm-discover-and-set-version
   if [ ! -z "$BASH"  ]; then
-    PROMPT_COMMAND=_jvm-discover-and-set-version
+    PROMPT_COMMAND=__jvm_main
     # shellcheck disable=SC2039
-    complete -W "$(_jvm-command-list)" jvm
+    complete -W "local global version reload config" jvm
   elif [ ! -z "$ZSH_NAME" ]; then
     chpwd() {
-      _jvm-discover-and-set-version
+      __jvm_main
+    }
+    _jvm() {
+      _arguments "1: :(local global version reload config)"
     }
     # shellcheck disable=SC2039
-    _jvm-completions() {
-      # shellcheck disable=SC2039,SC2034
-      IFS=' ' read -r -A reply <<< "$(_jvm-command-list)"
-    }
-    compctl -K _jvm-completions jvm
+    compdef _jvm jvm
   fi
 }
 

--- a/jvm.sh
+++ b/jvm.sh
@@ -35,7 +35,8 @@ __jvm_set() {
 __jvm_set_pom_version() {
   MAVEN_OPTS="" mvn help:evaluate \
     -Dexpression='maven.compiler.source' |
-    grep -v INFO | grep -v WARN | cut -f2 -d'.' > .java-version
+    grep -e '^1\.[4-9]$' |
+    cut -f2 -d'.' > .java-version
 }
 
 # finds out which java version should be used.

--- a/tests/grep/pom.xml
+++ b/tests/grep/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.jvm</groupId>
+  <artifactId>jdk8</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.5.1</version>
+          <configuration>
+            <source>1.7</source>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/tests/java7/pom.xml
+++ b/tests/java7/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.jvm</groupId>
+  <artifactId>jdk7</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+  </properties>
+</project>

--- a/tests/java8/pom.xml
+++ b/tests/java8/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.jvm</groupId>
+  <artifactId>jdk8</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+</project>

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -xeo pipefail
 find . -name '.java-version' -delete
 
 ROOT="$(pwd)"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -17,6 +17,12 @@ test_pom7() {
   assert_java 7
 }
 
+test_pom7_grep() {
+  cd "$ROOT/$TESTS"/grep
+  jvm reload
+  assert_java 7
+}
+
 test_pom8() {
   cd "$ROOT/$TESTS"/java8
   jvm reload
@@ -39,3 +45,6 @@ test "$TRAVIS_OS_NAME" != "osx" && test_pom8
 
 echo "cdwd java 7 pom"
 test_pom7
+
+echo "cdwd java 7 grep"
+test_pom7_grep

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,9 +1,41 @@
 #!/bin/bash
 set -eo pipefail
-echo 8 > .java-version
+find . -name '.java-version' -delete
+
+ROOT="$(pwd)"
+TESTS="$(dirname "${BASH_SOURCE[0]}")"
+
+assert_java() {
+  version="$1"
+  test "$(jvm version)" = "$version" || exit 1
+  echo "$JAVA_HOME" | grep "$version" || exit 1
+}
+
+test_pom7() {
+  cd "$ROOT/$TESTS"/java7
+  jvm reload
+  assert_java 7
+}
+
+test_pom8() {
+  cd "$ROOT/$TESTS"/java8
+  jvm reload
+  assert_java 8
+}
+
 # shellcheck disable=SC1091
 source jvm.sh
+
+echo "jvm global 8"
+jvm global 8
+assert_java 8
+
+echo "jvm global 7"
 jvm local 7
-jvm reload
-test "$(jvm version)" = "7" || echo "jvm version should be 7"
-echo "$JAVA_HOME" | grep 7
+assert_java 7
+
+echo "cdwd java 7 pom"
+test_pom7
+
+echo "cdwd java 8 pom"
+test_pom8

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xeo pipefail
+set -eo pipefail
 find . -name '.java-version' -delete
 
 ROOT="$(pwd)"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-set -eo pipefail
-find . -name '.java-version' -delete
-
+set -xeo pipefail
 ROOT="$(pwd)"
 TESTS="$(dirname "${BASH_SOURCE[0]}")"
 
@@ -29,6 +27,8 @@ test_pom8() {
   assert_java 8
 }
 
+find . -name '.java-version' -delete
+
 # shellcheck disable=SC1091
 source jvm.sh
 
@@ -36,7 +36,7 @@ echo "jvm global 8"
 jvm global 8
 test "$TRAVIS_OS_NAME" != "osx" && assert_java 8
 
-echo "jvm global 7"
+echo "jvm local 7"
 jvm local 7
 assert_java 7
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-set -xeo pipefail
+set -eo pipefail
 ROOT="$(pwd)"
 TESTS="$(dirname "${BASH_SOURCE[0]}")"
 
 assert_java() {
   version="$1"
   test "$(jvm version)" = "$version" || exit 1
-  echo "$JAVA_HOME" | grep "$version" || exit 1
 }
 
 test_pom7() {
@@ -34,14 +33,14 @@ source jvm.sh
 
 echo "jvm global 8"
 jvm global 8
-test "$TRAVIS_OS_NAME" != "osx" && assert_java 8
+assert_java 8
 
 echo "jvm local 7"
 jvm local 7
 assert_java 7
 
 echo "cdwd java 8 pom"
-test "$TRAVIS_OS_NAME" != "osx" && test_pom8
+test_pom8
 
 echo "cdwd java 7 pom"
 test_pom7

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -28,14 +28,14 @@ source jvm.sh
 
 echo "jvm global 8"
 jvm global 8
-assert_java 8
+test "$TRAVIS_OS_NAME" != "osx" && assert_java 8
 
 echo "jvm global 7"
 jvm local 7
 assert_java 7
 
+echo "cdwd java 8 pom"
+test "$TRAVIS_OS_NAME" != "osx" && test_pom8
+
 echo "cdwd java 7 pom"
 test_pom7
-
-echo "cdwd java 8 pom"
-test_pom8

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-set -xeo pipefail
+set -eo pipefail
 echo 8 > .java-version
 # shellcheck disable=SC1091
 source jvm.sh
 jvm local 7
 jvm reload
-if ! [ "$(jvm version)" -eq 7 ]; then
-  echo "jvm version should be 7"
-fi
+test "$(jvm version)" = "7" || echo "jvm version should be 7"
 echo "$JAVA_HOME" | grep 7


### PR DESCRIPTION
- added proper usage/help
- removed a lot of shellcheck warnings
- make the script waaaaaaaaaaaay more readable (and easy to change)
- fixed a bug that happened when the user has a custom java in `~/.jvm-config`, but that's not the java version he wants now
- documented the script
- improved autocompletion
- fixed a bug in which running `jvm local` or `jvm global` would empty the file
- added more tests
- updated submodule (shellchecker)
### change of behavior

Now, instead of sed into pom.xml for an infinite amount of possibilities to try to find the java version, later on failing anyway because you are in a submodule of a maven project, `jvm` will try a regex with grep, and, if fails, it will use `mvn help:evaluate` to find out that info, caching it into `.java-version` (good thing to add this to your `~/.gitignore`.

Now, cd-ing into submodules WILL WORK :tada: and the version will be "cached", so, the next time you cd to the same folder it will be blazing fast.

This means that `jvm` can now also resolve java versions set in parent poms :+1: 

So, this fixes #40 , closes #38 , resolves #39 and definitely keep closed #34. 
