### PR TITLE
Add clitest tests

### DIFF
--- a/tests/test.clitest
+++ b/tests/test.clitest
@@ -1,0 +1,25 @@
+$ ROOT="$(pwd)"
+$ TESTS="tests"
+$ find . -name '.java-version' -delete
+$ source jvm.sh
+$ jvm global 8              # global
+$ jvm version
+8
+$ jvm local 7               # local
+$ jvm version
+7
+$ cd "$ROOT/$TESTS/java8"   # test pom 8
+$ jvm reload
+$ jvm version
+8
+$ cd "$ROOT/$TESTS/java7"   # test pom 7
+$ jvm reload
+$ jvm version
+7
+$ cd "$ROOT/$TESTS/grep"    # test pom 7 grep
+$ jvm reload
+$ jvm version
+7
+$ cd "$ROOT"
+$ find . -name '.java-version' -delete
+$

--- a/tests/test.clitest.md
+++ b/tests/test.clitest.md
@@ -1,0 +1,67 @@
+# jvm test suite
+
+Initial setup
+
+```console
+$ ROOT="$(pwd)"
+$ TESTS="tests"
+$ find . -name '.java-version' -delete
+$ source jvm.sh
+$
+```
+
+Test global
+
+```console
+$ jvm global 8
+$ jvm version
+8
+$
+```
+
+Test local
+
+```console
+$ jvm local 7
+$ jvm version
+7
+$
+```
+
+Test POM 8
+
+```console
+$ cd "$ROOT/$TESTS/java8"
+$ jvm reload
+$ jvm version
+8
+$
+```
+
+Test POM 7
+
+```console
+$ cd "$ROOT/$TESTS/java7"
+$ jvm reload
+$ jvm version
+7
+$
+```
+
+Test POM 7 grep
+
+```console
+$ cd "$ROOT/$TESTS/grep"
+$ jvm reload
+$ jvm version
+7
+$
+```
+
+Cleanup
+
+```console
+$ cd "$ROOT"
+$ find . -name '.java-version' -delete
+$
+```


### PR DESCRIPTION
This is not a "please merge this PR" PR, it is a marketing peace to to show off [clitest](https://github.com/aureliojargas/clitest) :smile: 

Here's the `tests/test.sh` script converted to use clitest.

I have made two versions, you can use whichever fits your style:
- `tests/test.clitest` - Plain command line history
- `tests/test.clitest.md` - Testable Markdown document, it's documentation and test file at the same time.

Having clitest installed in your system, just run:

``` console
$ bash clitest tests/test.clitest.md
#1  ROOT="$(pwd)"
#2  TESTS="tests"
#3  find . -name '.java-version' -delete
#4  source jvm.sh
#5  jvm global 8
#6  jvm version
#7  jvm local 7
#8  jvm version
#9  cd "$ROOT/$TESTS/java8"
#10 jvm reload
#11 jvm version
#12 cd "$ROOT/$TESTS/java7"
#13 jvm reload
#14 jvm version
#15 cd "$ROOT/$TESTS/grep"
#16 jvm reload
#17 jvm version
#18 cd "$ROOT"
#19 find . -name '.java-version' -delete
OK: 19 of 19 tests passed
$
```

Profit!

Test file rendered: https://github.com/aureliojargas/jvm/blob/clitest/tests/test.clitest.md
