### PR TITLE
dont override prompt command

### DIFF
--- a/jvm.sh
+++ b/jvm.sh
@@ -154,7 +154,7 @@ jvm() {
 # main function called when sourced.
 main() {
   if [ -n "$BASH"  ]; then
-    PROMPT_COMMAND=__jvm_main
+    PROMPT_COMMAND="__jvm_main; $PROMPT_COMMAND"
     # shellcheck disable=SC2039
     complete -W "local global version reload config" jvm
   elif [ -n "$ZSH_NAME" ]; then


### PR DESCRIPTION
`jvm` was overriding the bash prompt.

Now it composes it.

thanks @velo :beers: 
