### PR TITLE
Non java projects with pom.xml files / slowness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 > The _"Java Version Manager"_
 
-Automatically change `JAVA_HOME` based on current directory `.java-version`
-file.
+Automatically change `JAVA_HOME` and `PATH` based on current directory
+`.java-version` or `pom.xml` files.
 
 The philosophy behind this project is to simplify and automate the `JAVA_HOME`
 changing, much like `rbenv` and `rvm` do for Ruby.
@@ -24,11 +24,13 @@ $ echo "source ~/.jvm/jvm.sh" >> ~/.bashrc
 $ echo "source ~/.jvm/jvm.sh" >> ~/.zshrc
 ```
 
-Then, just `cd` to a java project folder. `jvm` will try to extract the version
-using a regular expression. If that fails, `jvm` will then call
-`mvn help:evaluate` asking for the source compiler version, and then, set it to
-`.java-version`. If the `.java-version` file already exists, it will just use
-what's in there.
+Then, just `cd` to a java project folder. `jvm` will look for a `.java-version`
+and use whatever version is inside it. If the file don't exist, but a
+`pom.xml` do, `jvm` will try to extract the version from the `pom.xml` file
+using a regular expression.
+
+`jvm` can also recursively search for `.java-version` and `pom.xml` files, so,
+`cd`-ing to project's subfolder should maintain its version set.
 
 You can always change the current folder java version by doing:
 
@@ -65,3 +67,11 @@ $ antibody bundle caarlos0/jvm
 ```
 
 And it should all work out of the box.
+
+# Honorable mentions
+
+- [@aureliojargas](https://github.com/aureliojargas) for helping review `jvm.sh`
+and for rewrite my test suite with
+[clitest](https://github.com/aureliojargas/clitest);
+- [@velo](https://github.com/velo) for helping me test (on Windows), reporting
+bugs and giving some useful suggestions.

--- a/jvm.sh
+++ b/jvm.sh
@@ -37,16 +37,6 @@ __jvm_set() {
   export PATH="${JAVA_HOME}/bin:$PATH"
 }
 
-# evaluates the 'maven.compiler.source' expression, returning the found java
-# version
-# XXX this is slow as fuck, get rid of this!
-__jvm_pomversion_evaluate() {
-  MAVEN_OPTS="" mvn help:evaluate \
-    -Dexpression='maven.compiler.source' |
-    grep -e '^1\.[4-9]$' |
-    cut -f2 -d'.'
-}
-
 # tried to find the java version using regex.
 __jvm_pomversion_regex() {
   regex="<(java.version|maven.compiler.source|source)>1\.[4-9]</.*>"
@@ -61,7 +51,7 @@ __jvm_pomversion_regex() {
 # tries multiple strategies to find the java version, and then sets it in a
 # .java-version
 __jvm_pomversion() {
-  version="$(__jvm_pomversion_regex || __jvm_pomversion_evaluate)"
+  version="$(__jvm_pomversion_regex)"
   touch .java-version
   test -n "$version" && echo "$version" > .java-version
 }

--- a/jvm.sh
+++ b/jvm.sh
@@ -81,10 +81,9 @@ __jvm_version() {
   version="$(__jvm_local_version "$proj")"
 
   # try to extract from pom.xml
-  test -z "$version" &&
-    version="$(__jvm_pomversion "$proj")"
+  test -z "$version" && version="$(__jvm_pomversion "$proj")"
 
-  # if parent pom or .java-version exists, try to find the verion there.
+  # go up looking for pom.xmls and .java-versions
   parent="$proj/.."
   test -z "$version" &&
     test -f "$parent/pom.xml" -o -f "$parent/.java-version" &&

--- a/jvm.sh
+++ b/jvm.sh
@@ -39,6 +39,7 @@ __jvm_set() {
 
 # evaluates the 'maven.compiler.source' expression, returning the found java
 # version
+# XXX this is slow as fuck, get rid of this!
 __jvm_pomversion_evaluate() {
   MAVEN_OPTS="" mvn help:evaluate \
     -Dexpression='maven.compiler.source' |

--- a/jvm.sh
+++ b/jvm.sh
@@ -4,6 +4,7 @@ JVM_REGEX="<(java.version|maven.compiler.source|source)>1\.[4-9]</.*>"
 
 # finds the java home for the given version
 __jvm_javahome() {
+  # shellcheck disable=SC2039
   local version="$1"
 
   # custom jdk strategy
@@ -25,9 +26,11 @@ __jvm_javahome() {
 
 # find the appropriate JAVA_HOME for the given java version and fix PATH.
 __jvm_set() {
-  local version="$1"
-  local previous="$JAVA_HOME"
-  local new="$(__jvm_javahome "$version")"
+  # shellcheck disable=SC2039
+  local version previous new
+  version="$1"
+  previous="$JAVA_HOME"
+  new="$(__jvm_javahome "$version")"
 
   # PATH cleanup
   # shellcheck disable=SC2155
@@ -41,8 +44,9 @@ __jvm_set() {
 
 # tried to find the java version using regex.
 __jvm_pomversion() {
-  local tag
-  local pom="$1/pom.xml"
+  # shellcheck disable=SC2039
+  local tag pom
+  pom="$1/pom.xml"
   test ! -s "$pom" && return 1
   tag="$(grep -Eo "$JVM_REGEX" "$pom")"
   test -z "$tag" && return 1
@@ -54,6 +58,7 @@ __jvm_pomversion() {
 
 # tries to get the version from the local .java-version
 __jvm_local_version() {
+  # shellcheck disable=SC2039
   local file="$1/.java-version"
   test -s "$file" || return 1
   cat "$file"
@@ -67,8 +72,9 @@ __jvm_user_version() {
 
 # finds out which java version should be used.
 __jvm_version() {
-  local version parent
-  local proj="$1"
+  # shellcheck disable=SC2039
+  local version parent proj
+  proj="$1"
   test -z "$proj" && proj="."
 
   # try to load from .java-version
@@ -92,12 +98,15 @@ __jvm_version() {
 
 # called when a proj changes. Find which java version to use and sets it to PATH.
 __jvm_main() {
-  local version="$(__jvm_version)"
+  # shellcheck disable=SC2039
+  local version
+  version="$(__jvm_version)"
   test -n "$version" && __jvm_set "$version"
 }
 
 # edit custom java version configurations
 __jvm_config() {
+  # shellcheck disable=SC2039
   local file="$HOME/.jvmconfig"
   test ! -f "$file" && echo "custom-jdk=/path/to/custom/jdk" > "$file"
   $EDITOR "$file"
@@ -128,6 +137,7 @@ EOF
 # utilitary function to user interaction with the jvm configs
 # (and further scripting).
 jvm() {
+  # shellcheck disable=SC2039
   local command
   if [ "$#" != 0 ]; then
     command="$1"; shift

--- a/jvm.sh
+++ b/jvm.sh
@@ -96,7 +96,8 @@ __jvm_version() {
   echo "$version"
 }
 
-# called when a proj changes. Find which java version to use and sets it to PATH.
+# called when current pwd changes. Find which java version to use and sets
+# it to PATH.
 __jvm_main() {
   # shellcheck disable=SC2039
   local version

--- a/jvm.sh
+++ b/jvm.sh
@@ -61,18 +61,19 @@ __jvm_pomversion_regex() {
 # .java-version
 __jvm_pomversion() {
   version="$(__jvm_pomversion_regex || __jvm_pomversion_evaluate)"
+  touch .java-version
   test -n "$version" && echo "$version" > .java-version
 }
 
 # tries to get the version from the local .java-version
 __jvm_local_version() {
-  test -f .java-version || return 1
+  test -s .java-version || return 1
   cat .java-version
 }
 
 # tries to get the version from the user .java-version
 __jvm_user_version() {
-  test -f ~/.java-version || return 1
+  test -s ~/.java-version || return 1
   cat ~/.java-version
 }
 

--- a/tests/java8/empty/pom.xml
+++ b/tests/java8/empty/pom.xml
@@ -5,7 +5,6 @@
     <groupId>com.jvm</groupId>
     <artifactId>jdk8</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <relativePath>../java8</relativePath>
   </parent>
   <groupId>com.jvm</groupId>
   <artifactId>empty</artifactId>

--- a/tests/nonjava/pom.xml
+++ b/tests/nonjava/pom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.jvm</groupId>
+  <artifactId>nonjava</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+</project>

--- a/tests/test.clitest.md
+++ b/tests/test.clitest.md
@@ -127,6 +127,6 @@ Remove unneeded files after all tests ran.
 $ cd "$ROOT"
 $ find . -name '.java-version' -delete
 $ echo "6=$(__jvm_javahome 7)" > ~/.jvmconfig
-$ jvm global 8 || true
+$ jvm global 8 2> /dev/null
 $
 ```

--- a/tests/test.clitest.md
+++ b/tests/test.clitest.md
@@ -12,6 +12,7 @@ $ TESTS="tests"
 $ find . -name '.java-version' -delete
 $ source jvm.sh
 $ export MAVEN_OPTS=""
+$ echo "8=$(__jvm_javahome 7)" > ~/.jvmconfig
 $
 ```
 
@@ -95,7 +96,7 @@ pointing out Java 6 to use Java 7 home.
 
 ```console
 $ cd "$ROOT/$TESTS/grep"
-$ echo "6=$(__jvm_javahome 7)" > ~/.jvmconfig
+$ echo "6=$(__jvm_javahome 7)" >> ~/.jvmconfig
 $ jvm local 6
 $ jvm reload
 $ jvm version
@@ -125,6 +126,7 @@ Remove unneeded files after all tests ran.
 ```console
 $ cd "$ROOT"
 $ find . -name '.java-version' -delete
+$ echo "6=$(__jvm_javahome 7)" > ~/.jvmconfig
 $ jvm global 8
 $
 ```

--- a/tests/test.clitest.md
+++ b/tests/test.clitest.md
@@ -111,11 +111,11 @@ java projects, will get an empty `.java-version` to avoid running `mvn`
 evaluate every time.
 
 ```console
-$ jvm global 8
+$ jvm global 7
 $ cd "$ROOT/$TESTS/nonjava"
 $ jvm reload
 $ jvm version
-8
+7
 $
 ```
 
@@ -127,6 +127,6 @@ Remove unneeded files after all tests ran.
 $ cd "$ROOT"
 $ find . -name '.java-version' -delete
 $ echo "6=$(__jvm_javahome 7)" > ~/.jvmconfig
-$ jvm global 8
+$ jvm global 8 || true
 $
 ```

--- a/tests/test.clitest.md
+++ b/tests/test.clitest.md
@@ -81,7 +81,7 @@ therefore, this will run `mvn help:evaluate` and find out that the parent
 is using Java 8.
 
 ```console
-$ cd "$ROOT/$TESTS/empty"
+$ cd "$ROOT/$TESTS/java8/empty"
 $ jvm reload
 $ jvm version
 8

--- a/tests/test.clitest.md
+++ b/tests/test.clitest.md
@@ -104,6 +104,22 @@ $ jvm version
 $
 ```
 
+# nonjava
+
+Test that a folder with a `pom.xml`, but which is not being used to compile
+java projects, will get an empty `.java-version` to avoid running `mvn`
+evaluate every time.
+
+```console
+$ jvm global 8
+$ cd "$ROOT/$TESTS/nonjava"
+$ jvm reload
+$ jvm version
+8
+$ test -f .java-version
+$
+```
+
 # Cleanup
 
 Remove unneeded files after all tests ran.
@@ -111,5 +127,6 @@ Remove unneeded files after all tests ran.
 ```console
 $ cd "$ROOT"
 $ find . -name '.java-version' -delete
+$ jvm global 8
 $
 ```

--- a/tests/test.clitest.md
+++ b/tests/test.clitest.md
@@ -95,7 +95,6 @@ pointing out Java 6 to use Java 7 home.
 
 ```console
 $ cd "$ROOT/$TESTS/grep"
-$ rm .java-version
 $ echo "6=$(__jvm_javahome 7)" > ~/.jvmconfig
 $ jvm local 6
 $ jvm reload
@@ -116,7 +115,6 @@ $ cd "$ROOT/$TESTS/nonjava"
 $ jvm reload
 $ jvm version
 8
-$ test -f .java-version
 $
 ```
 


### PR DESCRIPTION
> ~~Since now we are also using `mvn help:evaluate` to find out the java
> version, if the project uses maven but is not a java project (i.e.:
> scala, flex, etc), every call to `__jvm_main` will take A LOT of time
> and it will never find the java version in the pom.~~
> 
> ~~This pull fixes that by, when no java version is found in the pom,
> creating an empty `.java-version`, and later checking for existent,
> non-empty `.java-version`, or loading the user `.java-version`.~~
> 
> ~~It is not very elegant, but should solve the problem.~~

I was using  `mvn help:evaluate` to find out the java version and 
caching it in `.java-version` files. This could end up generating a
lot of `.java-version` files (which doesn't make sense) and also
take too much time to run. It ends up that going some folders
up looking for `pom.xml` and `.java-version` files is cheaper
than calling `mvn` (I know, big surprise :open_mouth: ).

So, now, going up instead of calling maven. Which ended up fixing
the issue first reported by @velo in which some non java projects
that had a `pom.xml` were getting evaluated every time.

Also added a test for that.
