### PR TITLE
should call main on shell load

### DIFF
--- a/jvm.sh
+++ b/jvm.sh
@@ -200,6 +200,7 @@ main() {
     # shellcheck disable=SC2039
     compctl -k "(local global version reload config)" jvm
   fi
+  __jvm_main
 }
 
 main


### PR DESCRIPTION
if a new shell is opened directly into a project folder, `cd` is never called and therefore jvm never gets the chance to run.

This should fix it.
